### PR TITLE
グループ機能のルーティングの設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'messages#index'
   resources :users, only: [:edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
 end


### PR DESCRIPTION
#What
グループ機能に必要な新規作成機能と編集機能のためのルーティングを定義した。

#Why
機能の実装にはルーティングの設定が不可欠な要素の一つだから。