### PR TITLE
アクションの定義

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,2 +1,16 @@
 class GroupsController < ApplicationController
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+    
+  end
 end


### PR DESCRIPTION
#What
グループコントローラーでアクションの大枠を定義した。

#Why
アクションの定義はグループ機能実装で不可欠なものだから。