### PR TITLE
グループ作成機能の実装

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,15 +1,28 @@
 class GroupsController < ApplicationController
 
   def new
+    @group = Group.new
+    @group.users << current_user
   end
 
   def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
   end
 
   def edit
   end
 
   def update
+  end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, { :user_ids => [] })
   end
     
 end

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,22 +1,27 @@
 .chat-group-form
   %h1 新規チャットグループ
-  %form#new_chat_group.new_chat_group{"accept-charset": "UTF-8", action: "/chat_groups", method: "post"}
-    %input{name: "utf8", type: "hidden", value: "✓"}/
-    %input{name: "authenticity_token", type: "hidden", value: "AxFKlYEhD6eqX1PiZoTYQDANtKvgcFSXZQXHt5hyTl55/U/CHC5rtPavrcu2za65riz4tekZEy56vP6kEb2wYA=="}/
-    .chat-group-form__field.clearfix
+  = form_for @group do |f|
+    - if @group.errors.any?
+      .chat-group-form__errors
+        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+        %ul
+          - @group.errors.full_messages.each do |message|
+            %li= message
+    .chat-group-form__field
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
+        = f.label :name, class: 'chat-group-form__label'
       .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text"}/
+        = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
     .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときに使用します
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+        %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
       .chat-group-form__field--right
         / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        / この部分はインクリメンタルサーチ(ユーザー追加の非同期化)のときにも使用します
+        = f.collection_check_boxes :user_ids, User.all, :id, :name
+        / この部分はインクリメンタルサーチ（ユーザー追加の非同期化)のときにも使用します
     .chat-group-form__field.clearfix
       .chat-group-form__field--left
       .chat-group-form__field--right
-        %input.chat-group-form__action-btn{"data-disable-with":"Save", name: "commit", type: "submit", value: "Save"}/
+        = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,6 +1,3 @@
-.flash
-  グループを作成しました
-
 .side
   .side__header
     .side__header--username


### PR DESCRIPTION
#What
newアクションに@groupというインスタンス変数を、createアクション内はグループ作成の可否にあわせた処理をそれぞれ定義した。
また、仮置きだったformタグ・inputタグを、form_forを使って書き直し、errors.full_messagesメソッドを利用しエラーメッセージを表示させた。

#Why
DBにグループのデータを保存するのに必要であり、作成に当たる処理もユーザーが機能を使う上で便利になるため。